### PR TITLE
conf: wrap os calls in try catch.

### DIFF
--- a/lib/conf.js
+++ b/lib/conf.js
@@ -11,8 +11,14 @@ var os = require('os')
   , filename = process.argv[1]
   ;
 
-const {username = 'seeli'} = os.userInfo()
-const host = os.hostname()
+let username = 'seeli'
+let host = 'local'
+try {
+  const info = os.userInfo()
+  host = os.hostname()
+  username = info.username
+} catch (_) {}
+
 const PS1 = `${username}@${host}`
 const name = filename ? path.basename(filename, '.js') : 'seeli'
 


### PR DESCRIPTION
There is an os call the tries to read user info, which can fail in
docker base environments. This wraps it in a try catch with a sane
fallback

Semver: patch