### PR TITLE
fix: correct release rules for semantic-release

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -15,7 +15,9 @@ module.exports = {
         ]
       }
     , releaseRules: [
-        {type: 'build', release: 'patch'}
+        {breaking: true, release: 'major'}
+      , {revert: true, release: 'patch'}
+      , {type: 'build', release: 'patch'}
       , {type: 'ci', release: 'patch'}
       , {type: 'release', release: 'patch'}
       , {type: 'chore', release: 'patch'}


### PR DESCRIPTION
configure all breaking changes as a major release and all
reverts as patch releases