### PR TITLE
fix(help): allow printing for invalid commands

### DIFF
--- a/lib/commands/help.js
+++ b/lib/commands/help.js
@@ -39,15 +39,37 @@ module.exports = new Command({
     })
 
     const commands = require('./')
-    const cls = lookup.length
+    let cls = lookup.length
       ? commands.resolve(lookup)
       : commands.get(cmd)
+
+    let output = []
+    if (cls === undefined && lookup.length) {
+      while (cls === undefined && lookup.length) {
+        // This means the last lookup failed.
+        // So, pop it off
+        const bad_command = lookup.pop()
+        const pre_command = conf.get('name') + ' ' + lookup.join(' ')
+        const len = pre_command.length + 1
+        output = [
+          'Invalid command:'
+        , ''
+        , `$ ${pre_command} ${this.colorize('red', bad_command)}`
+        , '-'.repeat(len + 2) + '^'.repeat(bad_command.length)
+        , ''
+        , `Below is the usage for ${this.colorize('bold', pre_command)}:`
+        , ''
+        ]
+
+        cls = commands.resolve(lookup)
+      }
+    }
 
     const instance = HELP_REGEX.test(cmd)
       ? this
       : typeof cls === 'function' ? new cls() : cls
 
-    let output = [instance.description]
+    output.push(instance.description)
 
     try {
       const breaker = '='.repeat(instance.description.length)


### PR DESCRIPTION
When an invalid subcommand is used, you can pass `data.argv.remain`
to the `help` command's run function and it will make it visible
what the error is.

Semver: patch

Here is an example:

```
./bin/cli.js --traceback help waves get app thing                                                                                                                                                            (show-app) 
Invalid command:

$ dna waves get app thing
--------------------^^^^^

Below is the usage for dna waves get app:

Used to get apps
================
dna waves get app [flags] [name]

Options:

  -i, --interactive, --no-interactive   <boolean> [false]             Use the interactive propmts
  --color, --no-color                   <boolean> [true]              Enable ANSI color in output


  <...>: input type | *: repeatable flags | [...]: default values

```