### PR TITLE
feat(seeli): add basic support for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,39 @@ node ./cli world --interactive
 node ./cli world --name=Mark --name=Sally --no-excited
 ```
 
+<!-- vim-markdown-toc GFM -->
 
+* [API](#api)
+  * [Seeli.run( )](#seelirun-)
+  * [Seeli.list`<Array>`](#seelilistarray)
+  * [Seeli.use( name `<string>`, cmd `<Command>` )](#seeliuse-name-string-cmd-command-)
+  * [Seeli.bold( text `<string>`)](#seelibold-text-string)
+  * [Seeli.green( text `<string>`)](#seeligreen-text-string)
+  * [Seeli.blue( text `<string>`)](#seeliblue-text-string)
+  * [Seeli.red( text `<string>`)](#seelired-text-string)
+  * [Seeli.yellow( text `<string>`)](#seeliyellow-text-string)
+  * [Seeli.cyan( text `<string>`)](#seelicyan-text-string)
+  * [Seeli.magenta( text `<string>`)](#seelimagenta-text-string)
+  * [Seeli.redBright( text `<string>`)](#seeliredbright-text-string)
+  * [Seeli.blueBright( text `<string>`)](#seelibluebright-text-string)
+  * [Seeli.greenBright( text `<string>`)](#seeligreenbright-text-string)
+  * [Seeli.yellowBright( text `<string>`)](#seeliyellowbright-text-string)
+  * [Seeli.cyanBright( text `<string>`)](#seelicyanbright-text-string)
+  * [Seeli.set( key `<string>`, value `<object>` )](#seeliset-key-string-value-object-)
+  * [Seeli.get( key `<string>` )](#seeliget-key-string-)
+      * [Supported Confgurations](#supported-confgurations)
+        * [Package Configuration](#package-configuration)
+  * [Command( options `<object>` )](#command-options-object-)
+  * [Options](#options)
+    * [Flag Options](#flag-options)
+      * [Nested Flags](#nested-flags)
+  * [Auto Help](#auto-help)
+  * [Asyncronous](#asyncronous)
+  * [Progress](#progress)
+  * [Events](#events)
+
+<!-- vim-markdown-toc -->
+# API
 
 ## Seeli.run( )
 
@@ -195,8 +227,28 @@ A config value to look up. Can be a dot separated key to look up nested values
 * name `<String>`   - the name of the command that is used in generated help
 * exitOnError `<Boolean>` - Seeli will forcefully exit the current process when an error is encountered. default `false`
 * exitOnContent `<Boolean>` - Seeli will forefully exit the current process when it is passed output content from a command. default `true`
+* plugins `<String>|<function>[]` - A list of plugins to load and execute. A plugin may be either a function, or a module id to be required.
+  If it is a module id, the module must export a single function which will be passed the seeli instance when called.
 * help `<String>`  - a file path or module name to a custom help command. This will be passed to `require` and must export a single command instance
     * `seeli.set('help', '/path/to/help/command')`
+
+##### Package Configuration
+
+Alternatively, initial configuration may be provided via `package.json` in a top-level key - `seeli`
+
+```json5
+// package.json
+
+{
+  "seeli": {
+    "color": "blue",
+    "name": "whizbang",
+    "plugins": [
+      "@myscope/simple-command"
+    ]
+  }
+}
+```
 
 ## Command( options `<object>` )
 

--- a/lib/exceptions.js
+++ b/lib/exceptions.js
@@ -148,9 +148,40 @@ class CommandException extends Error {
   }
 }
 
+class PluginException extends Error {
+  constructor(msg) {
+    super()
+    /**
+     * @readonly
+     * @instance
+     * @memberof module:seeli/lib/exceptions.PluginException
+     * @name name
+     * @property {String} name=PluginException Exception name
+     **/
+    this.name = 'PluginException'
+    /**
+     * @readonly
+     * @instance
+     * @memberof module:seeli/lib/exceptions.PluginException
+     * @name message
+     * @property {String} message Message to include in error output
+     **/
+    this.message = msg
+    /**
+     * @readonly
+     * @instance
+     * @memberof module:seeli/lib/exceptions.PluginException
+     * @name code
+     * @property {String} message A Unique error code identifier
+     **/
+    this.code = 'EPLUGIN'
+  }
+}
+
 module.exports = {
   RequiredFieldException: RequiredFieldException
 , InvalidFieldException: InvalidFieldException
 , UnknownFlagException: UnknownFlagException
 , CommandException: CommandException
+, PluginException: PluginException
 }

--- a/lib/seeli.js
+++ b/lib/seeli.js
@@ -1,13 +1,18 @@
 'use strict'
 
 const chalk = require('chalk')
+const toArray = require('mout/lang/toArray')
+const kindOf = require('mout/lang/kindOf')
 const Command = require('./command')
 const config = require('./conf.js')
+const {PluginException} = require('./exceptions.js')
 
 class Seeli extends Command {
   constructor(...args) {
     super({
       color: 'green'
+    , name: 'seeli'
+    , plugins: toArray(config.get('plugins'))
     , flags: {
         help: {
           type: Boolean
@@ -18,6 +23,8 @@ class Seeli extends Command {
         }
       }
     }, ...args)
+
+    this.plugin()
   }
 
   config(key, value) {
@@ -64,6 +71,40 @@ class Seeli extends Command {
       this.unregister(key)
     }
     this.clear()
+    return this
+  }
+
+  plugin(...args) {
+    const plugins = args.length ? args : this.options.plugins
+    for (const path of plugins) {
+      const type = kindOf(path).toLowerCase()
+      let plugin = null
+      let plugin_name = path
+
+      switch (type) {
+        case 'string': {
+          plugin_name = path
+          plugin = require(path)
+          break
+        }
+
+        case 'function': {
+          plugin_name = path.name || 'inline plugin'
+          plugin = path
+          break
+        }
+
+        default: {
+          throw new PluginException(
+            `Invalid plugin. Must be of type string or function. Got ${type}`
+          )
+        }
+      }
+
+      this.debug('loading plugin %s', plugin_name)
+      plugin.call(null, this)
+    }
+
     return this
   }
 }

--- a/package.json
+++ b/package.json
@@ -108,6 +108,10 @@
     "ts": false,
     "browser": false,
     "esm": false,
+    "functions": 93,
+    "lines": 94,
+    "branches": 78,
+    "statements": 92,
     "coverage-report": [
       "text",
       "text-summary",
@@ -118,7 +122,8 @@
     ],
     "nyc-arg": [
       "--exclude=test/",
-      "--exclude=examples/"
+      "--exclude=examples/",
+      "--all"
     ]
   }
 }

--- a/release.config.js
+++ b/release.config.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   branches: [
-    'master'
+    'main'
   ]
 , plugins: [
     ['@semantic-release/commit-analyzer', {

--- a/test/command.spec.js
+++ b/test/command.spec.js
@@ -76,6 +76,11 @@ test('command', async (t) => {
   // usage parsing
   t.test('~usage', async (t) => {
     t.test('should accept a single string', async (t) => {
+      t.on('end', () => {
+        cli.set('color', 'green')
+      })
+
+      cli.set('color', 'invalid')
       const UsageCommand = new Command({
         usage: "usage -a 'fake' --verbose"
       , args: ['--no-color']

--- a/test/fixtures/plugin-a.fixture
+++ b/test/fixtures/plugin-a.fixture
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = function(seeli) {
+  seeli.set('plugin_a_fixture', true)
+}

--- a/test/fixtures/plugin-b.fixture
+++ b/test/fixtures/plugin-b.fixture
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = function(seeli) {
+  seeli.set('plugin_b_fixture', true)
+}

--- a/test/seeli.spec.js
+++ b/test/seeli.spec.js
@@ -1,9 +1,21 @@
 'use strict'
 const os = require('os')
+const path = require('path')
 const {test} = require('tap')
 const cli = require('../')
+const config = require('../lib/conf.js')
+const Seeli = require('../lib/seeli.js')
+
+const FIXTURE_DIR = path.join(__dirname, 'fixtures')
 
 test('cli', async (t) => {
+  t.test('config', async (t) => {
+    const seeli = new Seeli()
+    t.notOk(seeli.config('foobar'), 'initial value not set')
+    seeli.config('foobar', 1)
+    t.strictEqual(seeli.config('foobar'), 1, 'config value set')
+  })
+
   t.test('#run', function(tt) {
     const help = cli.commands.get('help')
     help.once('content', (data) => {
@@ -30,7 +42,7 @@ test('cli', async (t) => {
     cli.run()
   })
 
-  t.test('color functions', async (tt) => {
+  t.test('color functions', async (t) => {
     const colors = [
       'red', 'blue', 'green'
     , 'yellow', 'bold', 'grey'
@@ -40,57 +52,57 @@ test('cli', async (t) => {
     ]
 
     for (const color of colors) {
-      tt.type(cli[color], Function, `${color} should be a top level function`)
+      t.type(cli[color], Function, `${color} should be a top level function`)
     }
   })
 
-  t.test('conf', async (tt) => {
-    tt.test('should store default values', async (ttt) => {
-      ttt.ok(cli.get('name'))
-      ttt.ok(cli.get('color'))
-      ttt.ok(cli.get('help'))
+  t.test('conf', async (t) => {
+    t.test('should store default values', async (t) => {
+      t.ok(cli.get('name'))
+      t.ok(cli.get('color'))
+      t.ok(cli.get('help'))
     })
 
-    tt.test('should allow arbitrary values', async (ttt) => {
+    t.test('should allow arbitrary values', async (t) => {
       cli.set('test', 1)
-      ttt.equal(cli.get('test'), 1)
+      t.equal(cli.get('test'), 1)
     })
 
-    tt.test('should allow setting multiple values', async (ttt) => {
+    t.test('should allow setting multiple values', async (t) => {
       cli.set({
         a: 1
       , b: 2
       , c: 3
       })
 
-      ttt.equal(cli.get('a'), 1, 'a===1')
-      ttt.equal(cli.get('b'), 2, 'b===2')
-      ttt.equal(cli.get('c'), 3, 'c===3')
+      t.equal(cli.get('a'), 1, 'a===1')
+      t.equal(cli.get('b'), 2, 'b===2')
+      t.equal(cli.get('c'), 3, 'c===3')
     })
   })
 
-  t.test('#use', async (tt) => {
-    tt.on('end', () => {
+  t.test('#use', async (t) => {
+    t.on('end', () => {
       cli.reset()
     })
     const TestCommand = new cli.Command()
 
-    tt.test('should allow commands to be registered by name', async (ttt) => {
+    t.test('should allow commands to be registered by name', async (t) => {
       cli.use('test', TestCommand)
-      ttt.notEqual(cli.list.indexOf('test'), -1)
+      t.notEqual(cli.list.indexOf('test'), -1)
     })
 
-    tt.test('#list', async (ttt) => {
-      ttt.test('should return an array', async (tttt) => {
-        tttt.ok(Array.isArray(cli.list))
+    t.test('#list', async (t) => {
+      t.test('should return an array', async (t) => {
+        t.ok(Array.isArray(cli.list))
       })
 
-      ttt.test('should only list top level commands', async (tttt) => {
-        tttt.notEqual(cli.list.indexOf('test'), -1)
-        tttt.notEqual(cli.list.indexOf('help'), -1)
-        tttt.equal(cli.list.indexOf('h'), -1)
-        tttt.equal(cli.list.indexOf('he'), -1)
-        tttt.equal(cli.list.indexOf('hel'), -1)
+      t.test('should only list top level commands', async (t) => {
+        t.notEqual(cli.list.indexOf('test'), -1)
+        t.notEqual(cli.list.indexOf('help'), -1)
+        t.equal(cli.list.indexOf('h'), -1)
+        t.equal(cli.list.indexOf('he'), -1)
+        t.equal(cli.list.indexOf('hel'), -1)
       })
     })
   })
@@ -128,6 +140,73 @@ test('cli', async (t) => {
     await runner.run()
     t.equal(process.exitCode, 1, 'exitCode set to 1')
     process.exitCode = undefined
+  })
+
+  t.test('plugin loading', async (t) => {
+    t.test('config loader', async (t) => {
+      t.on('end', () => {
+        config.set('plugins', [])
+      })
+
+      config.set('plugins', [
+        path.join(FIXTURE_DIR, 'plugin-a.fixture')
+      ])
+      const seeli = new Seeli()
+      t.strictEqual(seeli.get('plugin_a_fixture'), true, 'plugin path loaded')
+    })
+
+    t.test('require path loader', async (t) => {
+      const seeli = new Seeli({
+        plugins: [
+          path.join(FIXTURE_DIR, 'plugin-b.fixture')
+        ]
+      })
+
+      t.strictEqual(seeli.get('plugin_b_fixture'), true, 'plugin path loaded')
+    })
+
+    t.test('inline function loader', async (t) => {
+      function inline(s) {
+        const cmd = new Seeli({
+          name: 'manual'
+        })
+        s.reset()
+        s.set('inline_plugin', true)
+        s.use(cmd)
+      }
+
+      const seeli = new Seeli({
+        plugins: [inline]
+      })
+
+      t.strictEqual(seeli.get('inline_plugin'), true, 'inline plugin loaded')
+      t.deepEqual(seeli.list(), ['manual'], 'registered command list')
+    })
+
+    t.test('explicit call', async (t) => {
+      function outline(s) {
+        const cmd = new Seeli({
+          name: 'explicit'
+        })
+        s.reset()
+        s.set('outline_plugin', true)
+        s.use(cmd)
+      }
+
+      const seeli = new Seeli()
+      seeli.plugin(outline)
+
+      t.strictEqual(seeli.get('outline_plugin'), true, 'inline plugin loaded')
+      t.deepEqual(seeli.list(), ['explicit'], 'registered command list')
+    })
+
+    t.test('invalid plugin type', async (t) => {
+      t.throws(() => {
+        return new Seeli({
+          plugins: [1]
+        })
+      }, /invalid plugin. must be of type string or function. got number/i)
+    })
   })
 
 })


### PR DESCRIPTION
enable basic support for plugins. this allows for end users to develop
additional commands externally and load them dynamically.

a plugin can be an inline function or a string. if it is a string, it is
considered a require path and passed directly to require. The loaded
module should export a single function.

in both cases, the function is called with a null context and passed the
current instance of seeli

resolves: gh-39