### PR TITLE
fix(help): remove the interactive disablement on help command

### DIFF
--- a/lib/commands/help.js
+++ b/lib/commands/help.js
@@ -23,7 +23,6 @@ const HELP_REGEX = /help|hlep/
 module.exports = new Command({
   description: 'Displays information about available commands'
 , name: 'help'
-, interactive: false
 , get usage() {
     return [
       `${conf.get('name')} help <${colorize('command')}>`


### PR DESCRIPTION
If the help command is invoked manually from another command, it is
possible that the interactive flag is picked up. The help command will
complain about not allowing interactive mode and not the actual error.
Because help doesn't any flags, it typically won't matter if it is
allowed