### PR TITLE
fix(command): exclude interactive flag from tree if disabled

### DIFF
--- a/lib/command/index.js
+++ b/lib/command/index.js
@@ -583,13 +583,14 @@ class Command extends Registry {
   }
 
   get flags() {
-    const out = []
+    const flags = []
     for (const [name, flag] of Object.entries(this.options.flags)) {
+      if (name === 'interactive' && !this.options.interactive) continue
       const type = flagType(flag)
-      out.push(`--${name}`)
-      if (type === 'confirm') out.push(`--no-${name}`)
+      flags.push(`--${name}`)
+      if (type === 'confirm') flags.push(`--no-${name}`)
     }
-    return out
+    return flags
   }
 
   get tree() {
@@ -600,7 +601,8 @@ class Command extends Registry {
       const cmd = this.get(name)
       root[name] = cmd.tree
     }
-    root['--'] = root['-'] = flags
+    root['--'] = flags
+    root['-'] = flags
     return root
   }
 


### PR DESCRIPTION
If a command has interactive mode disabled, it should include the
interactive flags in the serlization tree