### PR TITLE
fix(seeli): expose Command as a getter on seeli

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,7 @@ const colors = [
 module.exports = commands
 
 commands.Seeli = Seeli
-commands.Command = Command
+
 Object.defineProperties(commands, {
   Seeli: {
     get: () => {

--- a/lib/seeli.js
+++ b/lib/seeli.js
@@ -37,6 +37,10 @@ class Seeli extends Command {
     return Command
   }
 
+  get Command() {
+    return Command
+  }
+
   constructor(...args) {
     super({
       color: 'green'

--- a/test/seeli.js
+++ b/test/seeli.js
@@ -26,8 +26,12 @@ test('cli', async (t) => {
       t.strictEqual(result, true, 'config value set')
     })
 
-    t.test('Command', async (t) => {
+    t.test('static get Command', async (t) => {
       t.strictEqual(Seeli.Command, Command, 'returns base command class')
+    })
+
+    t.test('instance get Command', async (t) => {
+      t.strictEqual(new Seeli().Command, Command, 'returns base command class')
     })
 
     t.test('colorize', async (t) => {


### PR DESCRIPTION
Rather than manually attaching the Command an instance on the way out,
expose a property getter on the instance so it can be accessed in the
same way the static property is