### PR TITLE
fix(command): stop ora instance after run is called

### DIFF
--- a/colorize.js
+++ b/colorize.js
@@ -1,2 +1,0 @@
-var colorize = require('./lib/colorize')
-console.log(colorize('test', 'ansi256:229'))

--- a/examples/package.json
+++ b/examples/package.json
@@ -17,7 +17,7 @@
     "seeli": "file:../"
   },
   "seeli": {
-    "color": "magenta",
+    "color": "ansi256:229",
     "name": "fake",
     "help": "./commands/ui"
   }

--- a/lib/command/index.js
+++ b/lib/command/index.js
@@ -291,7 +291,7 @@ class Command extends Registry {
   }
 
   invalidHandler(key, value, type) {
-    const got = color(typeOf(value))
+    const got = colorize(typeOf(value))
     const expected = colorize(typeOf(type))
     const msg = `${chalk.white('Expected')} ${expected} got ${got}`
     const error = new exceptions.InvalidFieldException(

--- a/lib/command/index.js
+++ b/lib/command/index.js
@@ -394,7 +394,9 @@ class Command extends Registry {
     this.dispatch()
     const run = this.options.run
     if (typeof run !== 'function') return
-    return this.options.run.call(this, cmd, this.parsed)
+    return this.options.run.call(this, cmd, this.parsed).finally(() => {
+      this.ui.stop()
+    })
   }
 
   /**
@@ -461,8 +463,10 @@ class Command extends Registry {
     this.validate(directive)
     this.dispatch()
 
-    const result = await this.options.run.call(this, directive, this.argv)
-    this.ui.stop()
+    const result = await this.options.run.call(this, directive, this.argv).finally(() => {
+      this.ui.stop()
+    })
+
     const content = !!this.argv.color ? result : strip(result)
     this.emit('content', content)
     return content

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,8 +15,6 @@ const chalk = require('chalk')
 const Command = require('./command')
 const Seeli = require('./seeli')
 const commands = require('./commands')
-const colorize = require('./colorize')
-const conf = require('./conf')
 
 const colors = [
   'red', 'blue', 'green'

--- a/lib/ora.js
+++ b/lib/ora.js
@@ -5,24 +5,24 @@ const colorize = require('./colorize')
 
 const instance = ora()
 
-const sourceFrame =  instance.constructor.prototype.frame
-
 instance.constructor.prototype.frame = frame
 
 module.exports = ora
 
 function frame() {
-  const {frames} = this.spinner;
-  let frame = frames[this.frameIndex];
+  const {frames} = this.spinner
+  let frame = frames[this.frameIndex]
 
   if (this.color) {
-    frame = colorize(frame, this.color);
+    frame = colorize(frame, this.color)
   }
 
-  this.frameIndex = ++this.frameIndex % frames.length;
-  const fullPrefixText = (typeof this.prefixText === 'string' && this.prefixText !== '') ? this.prefixText + ' ' : '';
-  const fullText = typeof this.text === 'string' ? ' ' + this.text : '';
+  this.frameIndex = ++this.frameIndex % frames.length
+  const fullText = typeof this.text === 'string' ? ' ' + this.text : ''
+  const fullPrefixText = (typeof this.prefixText === 'string' && this.prefixText !== '')
+    ? this.prefixText + ' '
+    : ''
 
-  return fullPrefixText + frame + fullText;
+  return fullPrefixText + frame + fullText
 }
 

--- a/test/colorize.js
+++ b/test/colorize.js
@@ -1,4 +1,5 @@
 'use strict'
+
 const {test} = require('tap')
 const colorize = require('../lib/colorize')
 

--- a/test/command.js
+++ b/test/command.js
@@ -67,7 +67,7 @@ test('command', async (t) => {
     , onContent: (content) => {
         t.equal(content, 'done', 'content also emitted')
       }
-    , run: function(cmd, data) {
+    , run: async function(cmd, data) {
         t.match(data, {
           foo: {
             bar: {
@@ -89,7 +89,7 @@ test('command', async (t) => {
     NestedCommand.once('content', (content) => {
       t.equal(content, 'done', 'content returned')
     })
-    NestedCommand.run()
+    await NestedCommand.run()
   })
 
   // usage parsing


### PR DESCRIPTION
add a finally handle to stop ui when the run call finishes. in the case of sub commands it isn't really possible to the top level seeli runner to interact with the deep command instance