### PR TITLE
fix(gh-pages): update node version to 14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
       - run: npm install
 
       - name: Publish


### PR DESCRIPTION
update the version of not for docs build to v14. v12 is no longer supported