### PR TITLE
fix(ci): update node matrix to reflect true level of support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [16.x, 18.x, 20.x]
 
     steps:
       - name: Checkout

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=16.0.0"
   },
   "bugs": {
     "url": "https://github.com/esatterwhite/node-seeli/issues"
@@ -107,14 +107,13 @@
     "eslint": "^7.31.0",
     "eslint-config-codedependant": "^2.1.6",
     "semantic-release": "^17.4.2",
-    "tap": "^14.10.2",
+    "tap": "^16.3.9",
     "vuepress": "^1.8.2"
   },
   "tap": {
     "jsx": false,
     "ts": false,
     "browser": false,
-    "esm": false,
     "functions": 93,
     "lines": 94,
     "branches": 78,


### PR DESCRIPTION
update the nodejs test matrix to run against 16, 18, and 20

BREAKING CHANGE: minimum version of node is 16