### PR TITLE
feat(command): add support for input filter for non-interactive

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,34 +114,34 @@ node ./cli world --name=Mark --name=Sally --no-excited
 <!-- vim-markdown-toc GFM -->
 
 * [API](#api)
-  * [Seeli.run( )](#seelirun-)
-  * [Seeli.list`<Array>`](#seelilistarray)
-  * [Seeli.use( name `<string>`, cmd `<Command>` )](#seeliuse-name-string-cmd-command-)
-  * [Seeli.bold( text `<string>`)](#seelibold-text-string)
-  * [Seeli.green( text `<string>`)](#seeligreen-text-string)
-  * [Seeli.blue( text `<string>`)](#seeliblue-text-string)
-  * [Seeli.red( text `<string>`)](#seelired-text-string)
-  * [Seeli.yellow( text `<string>`)](#seeliyellow-text-string)
-  * [Seeli.cyan( text `<string>`)](#seelicyan-text-string)
-  * [Seeli.magenta( text `<string>`)](#seelimagenta-text-string)
-  * [Seeli.redBright( text `<string>`)](#seeliredbright-text-string)
-  * [Seeli.blueBright( text `<string>`)](#seelibluebright-text-string)
-  * [Seeli.greenBright( text `<string>`)](#seeligreenbright-text-string)
-  * [Seeli.yellowBright( text `<string>`)](#seeliyellowbright-text-string)
-  * [Seeli.cyanBright( text `<string>`)](#seelicyanbright-text-string)
-  * [Seeli.config( key `<string>`, value `<object>` )](#seeliconfig-key-string-value-object-)
-  * [Seeli.config( opts `<object>` )](#seeliconfig-opts-object-)
-  * [Seeli.config( key `<string>` )](#seeliconfig-key-string-)
-      * [Supported Confgurations](#supported-confgurations)
-        * [Package Configuration](#package-configuration)
-  * [Command( options `<object>` )](#command-options-object-)
-  * [Options](#options)
-    * [Flag Options](#flag-options)
-      * [Nested Flags](#nested-flags)
-  * [Auto Help](#auto-help)
-  * [Asyncronous](#asyncronous)
-  * [Progress](#progress)
-  * [Events](#events)
+    * [Seeli.run( )](#seelirun-)
+    * [Seeli.list`<Array>`](#seelilistarray)
+    * [Seeli.use( name `<string>`, cmd `<Command>` )](#seeliuse-name-string-cmd-command-)
+    * [Seeli.bold( text `<string>`)](#seelibold-text-string)
+    * [Seeli.green( text `<string>`)](#seeligreen-text-string)
+    * [Seeli.blue( text `<string>`)](#seeliblue-text-string)
+    * [Seeli.red( text `<string>`)](#seelired-text-string)
+    * [Seeli.yellow( text `<string>`)](#seeliyellow-text-string)
+    * [Seeli.cyan( text `<string>`)](#seelicyan-text-string)
+    * [Seeli.magenta( text `<string>`)](#seelimagenta-text-string)
+    * [Seeli.redBright( text `<string>`)](#seeliredbright-text-string)
+    * [Seeli.blueBright( text `<string>`)](#seelibluebright-text-string)
+    * [Seeli.greenBright( text `<string>`)](#seeligreenbright-text-string)
+    * [Seeli.yellowBright( text `<string>`)](#seeliyellowbright-text-string)
+    * [Seeli.cyanBright( text `<string>`)](#seelicyanbright-text-string)
+    * [Seeli.config( key `<string>`, value `<object>` )](#seeliconfig-key-string-value-object-)
+    * [Seeli.config( opts `<object>` )](#seeliconfig-opts-object-)
+    * [Seeli.config( key `<string>` )](#seeliconfig-key-string-)
+            * [Supported Confgurations](#supported-confgurations)
+                * [Package Configuration](#package-configuration)
+    * [Command( options `<object>` )](#command-options-object-)
+    * [Options](#options)
+        * [Flag Options](#flag-options)
+            * [Nested Flags](#nested-flags)
+    * [Auto Help](#auto-help)
+    * [Asyncronous](#asyncronous)
+    * [Progress](#progress)
+    * [Events](#events)
 
 <!-- vim-markdown-toc -->
 # API
@@ -287,7 +287,7 @@ name | required | type | description
 **event**      | `false` | `boolean` | if set to `true` the command will emit an event withe the same name as the flag with **the** value that was captured for that flag |
 **when** | `false` | `function` | **interactive mode only** Receives the current user answers hash and should return true or **false** depending on whether or not this question should be asked.
 **validate** | `false` | `function` |  receives user input and should return true if the value is **valid**, and an error message (String) otherwise. If false is returned, a default error message is provided.
-**filter** | `false` | `function` | **interactive mode only** Receives the user input and return the filtered value to be used **inside** the program. The value returned will be added to the Answers hash.
+**filter** | `false` | `function` | Receives the user input and return the filtered value to be used **inside** the program. The value returned will be added to the Answers hash.
 
 #### Nested Flags
 

--- a/lib/command/index.js
+++ b/lib/command/index.js
@@ -237,7 +237,11 @@ class Command extends Registry {
         return this.parsed
       }
       const value = hasOwn(this.parsed, key) ? this.parsed[key] : flag.default
-      object.set(this.parsed, key, value)
+      object.set(
+        this.parsed
+      , key
+      , typeof flag.filter === 'function' ? flag.filter(value, this.parsed) : value
+      )
     }
     return this.parsed
   }
@@ -648,7 +652,7 @@ function toQuestion(flag, opts, answers) {
   // can return them
   arg.when = opts.when ? opts.when.bind(null, answers) : undefined
   arg.validate = opts.validate ? opts.validate.bind(null, answers) : undefined
-  arg.filter = opts.filter ? opts.filter.bind(null, answers) : undefined
+  arg.filter = opts.filter ? opts.filter.bind(null) : undefined
   arg.transformer = opts.transformer ? opts.transformer : transform.bind(arg)
   return arg
 }

--- a/test/command.js
+++ b/test/command.js
@@ -58,6 +58,9 @@ test('command', async (t) => {
       , 'foo:bar:baz': {
           type: Number
         , required: true
+        , filter(input) {
+            return input + 100
+          }
         }
       , 'nested:array': {
           type: [Number, Array]
@@ -71,7 +74,7 @@ test('command', async (t) => {
         t.match(data, {
           foo: {
             bar: {
-              baz: Number
+              baz: 112
             }
           }
         , test: Boolean


### PR DESCRIPTION
the input filter, previously supported for interactive mode via inquirer allow transformation of the input before validation happens. This allows for a great deal of functionality and flexibility for end users being able to fix typos, enter short hands, etc. This is being extended into the non-interactive commands as well