### PR TITLE
fix(command): fix typo in invalid field validation message

### DIFF
--- a/lib/command/index.js
+++ b/lib/command/index.js
@@ -299,7 +299,7 @@ class Command extends Registry {
     const expected = colorize(typeOf(type))
     const msg = `${chalk.white('Expected')} ${expected} got ${got}`
     const error = new exceptions.InvalidFieldException(
-      `Invalided Field Value for ${chalk.yellow(key)} - ${msg}`
+      `Invalid Field Value for ${chalk.yellow(key)} - ${msg}`
     )
     throw error
   }


### PR DESCRIPTION
The word invalid was misspelled.