### PR TITLE
fix(ci): make sure the release process publishes a pacakge

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -3,4 +3,5 @@
 module.exports = {
   'extends': '@codedependant/release-config-core'
 , 'branches': ['main']
+, 'npmPublish': true
 }


### PR DESCRIPTION
the core package has npm publish disabled by default. This enables it so the npm publish happens during the release process.