### PR TITLE
fix(command): fixes a prompt alias mismatch with select

### DIFF
--- a/lib/command/prompt-map.js
+++ b/lib/command/prompt-map.js
@@ -3,12 +3,12 @@
 const {checkbox, confirm, input, number, password, select} = require('@inquirer/prompts')
 
 module.exports = new Map([
-  ['checkbox', select]
+  ['checkbox', checkbox]
 , ['confirm', confirm]
 , ['input', input]
 , ['number', number]
 , ['password', password]
-, ['select', checkbox]
+, ['select', select]
 , ['multiselect', checkbox]
 , ['text', input]
 ])


### PR DESCRIPTION
select and check box prompt types were fliped such that specifying type checkbox would presnt a single select input