### PR TITLE
fix: publish root TypeScript declarations for CommonJS consumers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,11 @@
+import Command = require('./lib/command')
+import Seeli = require('./lib/seeli')
+
+declare const seeli: Seeli & {
+  Seeli: typeof Seeli
+  Command: typeof Command
+  list: string[]
+  [key: string]: any
+}
+
+export = seeli

--- a/lib/command/index.d.ts
+++ b/lib/command/index.d.ts
@@ -61,7 +61,7 @@ declare class Command extends Map<any, any> {
    * Will be passed the contents return by the command
    * @return String|undefined Will return the result from the command specific run directive if there is any.
    */
-  run(cmd?: any, depth?: number): Promise<any>;
+  run(cmd?: any, depth?: number): Promise<any> | undefined;
 
   /**
    * Validates the current data set before running the command

--- a/lib/seeli.d.ts
+++ b/lib/seeli.d.ts
@@ -1,73 +1,22 @@
+import Command = require('./command')
+
 /**
  * Seeli Entrypoint used for registering and managing commands
  * @module module:seeli/lib/seeli
  * @author Eric Satterwhite
  */
 declare class Seeli extends Command {
-  /**
-   * Get configuration value
-   * @param args Arguments to pass to config.get
-   */
   static get(...args: any[]): any;
-
-  /**
-   * Set configuration value
-   * @param args Arguments to pass to config.set
-   */
   static set(...args: any[]): any;
-
-  /**
-   * Colorize text with a specific color
-   * @param txt Text to colorize
-   * @param color Color to use
-   */
   static colorize(txt: string, color: string): string;
-
-  /**
-   * Get the Command class
-   */
   static get Command(): typeof Command;
-
-  /**
-   * Get the Command class
-   */
   get Command(): typeof Command;
-
-  /**
-   * Constructor for Seeli class
-   * @param args Arguments to pass to the constructor
-   */
   constructor(...args: any[]);
-
-  /**
-   * Colorize text with a specific color
-   * @param txt Text to colorize
-   * @param color Color to use
-   */
   colorize(txt: string, color: string): string;
-
-  /**
-   * Get or set configuration values
-   * @param args Arguments to pass to config
-   */
   config(...args: any[]): any;
-
-  /**
-   * Run the Seeli application
-   */
-  run(): void;
-
-  /**
-   * Reset the Seeli instance
-   */
+  run(...args: any[]): Promise<any> | undefined;
   reset(): Seeli;
-
-  /**
-   * Load plugins
-   * @param args Plugin arguments
-   */
   plugin(...args: any[]): Seeli;
 }
 
-export = Seeli;
-
+export = Seeli

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "files": [
     "index.js",
+    "index.d.ts",
     "lib/",
     "README.md",
     "LICENSE",
@@ -130,5 +131,6 @@
     "files": [
       "test/**/*.js"
     ]
-  }
+  },
+  "types": "./index.d.ts"
 }

--- a/test/flag-type.js
+++ b/test/flag-type.js
@@ -16,7 +16,7 @@ test('flagType', async (t) => {
   , [{type: [Number, Array]}, 'number', '[Number, Array] === number']
   , [{type: String, mask: true}, 'password', 'mask=true === password']
   , [{type: String, choices: []}, 'select', 'choices === select']
-  , [{type: String, choices: [], multi: true}, 'checkbox', 'choices + multi === checkbox'] // eslint-disable-line max-len
+  , [{type: String, choices: [], multi: true}, 'checkbox', 'choices + multi === checkbox']
   , [{type: Function}, 'input', 'unexpected type === input']
   ]
 


### PR DESCRIPTION
@algora-pbc /claim #135

This keeps the package CommonJS-first and avoids a build step, while making published typings usable from TypeScript NodeNext consumers.

What changed:
- add a root `index.d.ts` so `import seeli from "seeli"` resolves declarations from the package entrypoint
- publish that file via `files` and point `package.json#types` at it
- align existing declaration signatures with runtime behavior, especially `run()` paths that can return `undefined`

Verification:
- `npm test`
- `npm run lint` (warnings only from generated `.tap` report files, no errors)
- packed-package verification in a fresh consumer project:
  - `npx tsc --pretty false` with `module=NodeNext`
  - `require("seeli")`
  - `import seeli from "seeli"`

This follows the maintainer guidance from #135: CommonJS-first, no TypeScript build step, and focused on publishable type definitions rather than rewriting the runtime to TS/ESM.